### PR TITLE
Removes unused options from Axios plugin configuration

### DIFF
--- a/src/plugins/axios.js
+++ b/src/plugins/axios.js
@@ -39,7 +39,7 @@ _axios.interceptors.response.use(
   }
 );
 
-Plugin.install = function(Vue, options) {
+Plugin.install = function(Vue) {
   Vue.axios = _axios;
   window.axios = _axios;
   Object.defineProperties(Vue.prototype, {


### PR DESCRIPTION
This may need to be undone later, but for now it makes this error go away.

```
Failed to compile.

./src/plugins/axios.js
Module Error (from ./node_modules/eslint-loader/index.js):

42:32 error 'options' is defined but never used (no-unused-vars)
```